### PR TITLE
Added support for area polygon

### DIFF
--- a/pogom/__init__.py
+++ b/pogom/__init__.py
@@ -5,5 +5,6 @@ config = {
     'LOCALE': 'en',
     'LOCALES_DIR': 'static/locales',
     'ROOT_PATH': None,
-    'GOOGLEMAPS_KEY': 'GMAPS KEY HERE'
+    'GOOGLEMAPS_KEY': 'GMAPS KEY HERE',
+    'AREA_POLYGON': []
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ protobuf-to-dict==0.1.0
 geographiclib==1.46.3
 pycurl==7.43.0
 certifi==2016.2.28
+matplotlib==1.5.1


### PR DESCRIPTION
To make the scanning process of my non-round shaped city even faster, I added an array to the config object in `__init__.py` where you can set the points of a polygon `'AREA_POLYGON': [ [lat, long], [lat, long], ... ]` where `lat` and `long` are numbers. If the array isn't empty, only the points of the circle within this polygon will be scanned.

Without:
`2016-07-27 00:53:26,486 [     search] [   INFO] Starting scan of 12108 locations`

With:
`2016-07-27 00:52:35,456 [     search] [   INFO] Starting scan of 2097 locations`

The coordinates of the result area plotted on google maps:

![area](https://cloud.githubusercontent.com/assets/2354788/17158126/4b859cc2-5394-11e6-81cb-e010421baa41.PNG)

The result:

![cropped](https://cloud.githubusercontent.com/assets/2354788/17158131/51583254-5394-11e6-883b-fb61fba464ac.PNG)


