### PR TITLE
Allow new scan to begin immediately after location change

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -219,7 +219,12 @@ def throttle():
     sleep_time = max(min_time_per_scan - (time.time() - scan_start_time), 0)
     log.info("Scan finished. Sleeping {:.2f} seconds before continuing.".format(sleep_time))
     SearchConfig.LAST_SUCCESSFUL_REQUEST = -1
-    time.sleep(sleep_time)
+    while sleep_time > 0:
+        if SearchConfig.CHANGE:
+            break
+        time.sleep(1)
+        sleep_time -= 1
+
 
 
 def search_loop_async(args):


### PR DESCRIPTION
I noticed that when I use pogom and want to change the scanned location, I don't want to wait for a sleep cycle to finish until my newly selected location is scanned.

With this PR, pogom will begin scanning the new location as soon as it detects a location change.

Hopefully this follows your no-bloat philosophy :).