### PR TITLE
Added links back to the map on the config page

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -18,7 +18,7 @@
 <div class="container col-md-6 col-md-offset-3">
     <h1>PoGoMap Config</h1>
     {% if alert %}
-    <div class="alert alert-success" role="alert" id="alert-success" style="">Success! Config has been changed.</div>
+    <div class="alert alert-success" role="alert" id="alert-success" style="">Success! Config has been changed. <a href="../">Click here to return to the map.</a></div>
     {% endif %}
     <form method="POST" action="config">
       <div class="form-group">
@@ -38,7 +38,8 @@ username2:password2">
         <input type="password" class="form-control" id="configPassword" name="configPassword" value="{{ password or ''}}">
         <span id="configPasswordHelp" class="help-block">Protect this config with a password.</span>
       </div>
-      <button type="submit" class="btn btn-default">Submit</button>
+      <button type="submit" class="btn btn-primary">Submit</button>
+      <a href="../" class="btn btn-default">Back to Map</a>
     </form>
 </div>
 


### PR DESCRIPTION
This one's simple. I added two links from the config page back to the main map. One near the Submit button as kind of a 'Cancel' (Also I made the Submit a btn-primary to stand out), and another as a link inside the 'Success! Config has been changed' alert.