### PR TITLE
Added label to menu showing current full scan percentage

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -151,7 +151,8 @@ class Pogom(Flask):
         d['server_status'] = {'num-threads': ScanMetrics.NUM_THREADS,
                               'num-accounts': ScanMetrics.NUM_ACCOUNTS,
                               'last-successful-request': time_since_last_req,
-                              'complete-scan-time': ScanMetrics.COMPLETE_SCAN_TIME}
+                              'complete-scan-time': ScanMetrics.COMPLETE_SCAN_TIME,
+                              'current-scan-percent': ScanMetrics.CURRENT_SCAN_PERCENT}
 
         d['scan_locations'] = self.scan_config.SCAN_LOCATIONS
 

--- a/pogom/scan.py
+++ b/pogom/scan.py
@@ -33,6 +33,7 @@ class ScanMetrics:
     COMPLETE_SCAN_TIME = 0
     NUM_THREADS = 0
     NUM_ACCOUNTS = 0
+    CURRENT_SCAN_PERCENT = 0.0
 
 
 class Scanner(Thread):
@@ -67,7 +68,8 @@ class Scanner(Thread):
             ScanMetrics.CONSECUTIVE_MAP_FAILS += 1
         else:
             ScanMetrics.STEPS_COMPLETED += 1
-            log.info('Completed {:5.2f}% of scan.'.format(float(ScanMetrics.STEPS_COMPLETED) / ScanMetrics.NUM_STEPS * 100))
+            ScanMetrics.CURRENT_SCAN_PERCENT = float(ScanMetrics.STEPS_COMPLETED) / ScanMetrics.NUM_STEPS * 100
+            log.info('Completed {:5.2f}% of scan.'.format(ScanMetrics.CURRENT_SCAN_PERCENT))
 
     def scan(self):
         ScanMetrics.NUM_STEPS = len(self.scan_config.COVER)

--- a/static/map.js
+++ b/static/map.js
@@ -4,6 +4,7 @@ var $numThreads = $(".num-threads");
 var $numAccounts = $(".num-accounts");
 var $lastRequestLabel = $(".last-request");
 var $fullScanLabel = $(".full-scan");
+var $scanPercentLabel = $(".current-scan-percent");
 
 var $selectExclude = $("#exclude-pokemon");
 var excludedPokemon = [];
@@ -517,6 +518,17 @@ function statusLabels(status) {
     var timeSinceScan = status['complete-scan-time'];
     if (timeSinceScan)
         $fullScanLabel.html("Last full scan in "+ formatTimeDiff(timeSinceScan))
+    
+    var currentScanPercent = status['current-scan-percent'];
+    var currentScanPercentString = Number((currentScanPercent).toFixed(2)).toString();
+    $scanPercentLabel.html("Current full scan percent: "+currentScanPercentString+"%");
+    if (currentScanPercent > 0) {
+        $scanPercentLabel.removeClass('label-grey');
+        $scanPercentLabel.addClass('label-success');
+    } else {
+        $scanPercentLabel.removeClass('label-success');
+        $scanPercentLabel.addClass('label-grey');
+    }
 
 }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -211,6 +211,7 @@ span.select2 { width: 100% !important; }
                         <br />
                         <span class='last-request label label-warning'>No scans yet</span>
                         <span class='full-scan label label-grey'>No full scan yet</span>
+                        <span class='current-scan-percent label label-grey'>Current full scan percent: 0.00%</span>
                         <span class='num-threads label label-grey'>0 Threads</span>
                         <span class='num-accounts label label-grey'>0 Accounts</span>
                     </p>


### PR DESCRIPTION
Added a label to the menu showing the current full scan percentage, so you don't need to look back at the server console.

Label is grey when at 0 (Assumed not running), green otherwise (since it loops so low isn't necessarily bad).