### PR TITLE
Fixed reappearing scanLocation markers on page refresh

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -169,6 +169,12 @@ function initMap() {
     updateScanLocations(initialScanLocations);
     updateMap();
 
+	if(document.getElementById('coverage-checkbox').checked == false) {
+		scanLocations.forEach(function (scanLocation, key) {
+			scanLocation.marker.setVisible(false);
+		}, this);
+	}
+	
     if(is_logged_in()) {
         // on click listener for
         google.maps.event.addListener(map, 'click', function(event) {


### PR DESCRIPTION
The scanLocation markers reappeared on the map when refreshing the page even if the coverage-checkbox was set to false.