### PR TITLE
Protect PoGoMap with password

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -34,11 +34,15 @@ def read_config(scan_config):
     config['LOCALE'] = c.get('LOCALE', 'en')
     config['GOOGLEMAPS_KEY'] = c.get('GOOGLEMAPS_KEY', None)
     config['CONFIG_PASSWORD'] = c.get('CONFIG_PASSWORD', None)
+    config['SITE_PASSWORD'] = c.get('SITE_PASSWORD', None)
     config['ACCOUNTS'] = c.get('ACCOUNTS', [])
     scan_config.update_scan_locations(c.get('SCAN_LOCATIONS', {}))
 
     if config.get('CONFIG_PASSWORD', None):
         config['AUTH_KEY'] = ''.join(random.choice(string.lowercase) for _ in range(32))
+
+    if config.get('SITE_PASSWORD', None):
+        config['SITE_AUTH_KEY'] = ''.join(random.choice(string.lowercase) for _ in range(32))
 
 
 if __name__ == '__main__':

--- a/templates/config.html
+++ b/templates/config.html
@@ -44,8 +44,13 @@ username2:password2">
 			</div>
 			<div class="form-group">
 				<label for="configPassword">Config Password</label>
-				<input type="password" class="form-control" id="configPassword" name="configPassword" value="{{ password or ''}}">
+				<input type="password" class="form-control" id="configPassword" name="configPassword" value="{{ config_password or ''}}">
 				<span id="configPasswordHelp" class="help-block">Protect this config with a password.</span>
+			</div>
+			<div class="form-group">
+				<label for="sitePassword">Site Password</label>
+				<input type="password" class="form-control" id="sitePassword" name="sitePassword" value="{{ site_password or ''}}">
+				<span id="sitePasswordHelp" class="help-block">Protect this website with a password.</span>
 			</div>
 			<button type="submit" class="btn btn-primary">Submit</button>
 			<a href="../" class="btn btn-default">Back to Map</a>

--- a/templates/map.html
+++ b/templates/map.html
@@ -45,10 +45,10 @@ body {
     cursor: pointer;
     opacity: 0;
     /* hide this */
-    
+
     z-index: 2;
     /* and place it over the hamburger */
-    
+
     -webkit-touch-callout: none;
 }
 /*
@@ -122,7 +122,7 @@ body {
     list-style-type: none;
     -webkit-font-smoothing: antialiased;
     /* to stop flickering of text in safari */
-    
+
     transform-origin: 0% 0%;
     transform: translate(-100%, 0);
     -webkit-transform-origin: 0% 0%;
@@ -200,7 +200,7 @@ span.select2 {
 			<div id="menu-container">
 				<h1>Settings</h1>
 				<p style="margin: 8px 0">
-					{% if is_authenticated %}
+					{% if is_admin %}
 					<span class="auth-status label label-success">Authenticated</span> {% else %}
 					<span class="auth-status label label-warning"><a href="login" style="color: white; text-decoration: inherit;">Not authenticated</a></span> {% endif %}
 					<span class="last-request label label-warning">No scans yet</span>


### PR DESCRIPTION
Allows user to define a password to protect the website.
This does not conflict with the configuration password.
Also renamed `is_authenticated` to `is_admin` because only admins can change the config and add/delete points to/from the map.